### PR TITLE
Phasedisplay

### DIFF
--- a/data/HJMindex.html
+++ b/data/HJMindex.html
@@ -55,7 +55,7 @@
     <script src="hjm.js"></script>
     <script>
         update() // fill fist-time data
-        var timer = setInterval(update, 3 * 1000) // update every n seconds
+        var timer = setInterval(update, 2 * 1000) // update every n seconds
     </script>
 </body> 
 </html>

--- a/data/HJMindex.html
+++ b/data/HJMindex.html
@@ -6,33 +6,51 @@
     <link rel=icon href=/favicon.ico> <title>kW trend</title>
     <link href="https://fonts.googleapis.com/css?family=Dosis:400,700" rel="stylesheet">
     <link href="hjm.css" rel="stylesheet">
-    <script src="hjm.js"></script>
+
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/highcharts-more.js"></script>
+    <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
+    
 </head>
   
 <body><noscript><strong>Please enable JavaScript to continue.</strong></noscript>
     <div class=outer>
         <div class=card id=l1>
             <h1 id=power_delivered_l1h>Phase 1</h1>
-            <h2 id=power_delivered_l1>0.0</h2>
-            <h3><span id=power_delivered_l1a>0</span><span> Amp</span></h3>
-            <h2 id=power_delivered_l1p>0.0</h2>
+	        <div class="chart-container" id="container-1">I</div>
+            <hr/>
+            <div style="text-align:center">Kilowatt</div>
+            <h2 id="power_delivered_l1">0.0</h2>
+            <h2 id="power_delivered_l1p">0.0</h2>
         </div>
         <div class=card id=l2>
             <h1 id=power_delivered_l2h>Phase 2</h1>
+            <div class="chart-container" id="container-2">II</div>
+            <hr/>
+            <div style="text-align:center">Kilowatt</div>
             <h2 id=power_delivered_l2>0.0</h2>
-            <h3><span id=power_delivered_l2a>0</span><span> Amp</span></h3>
             <h2 id=power_delivered_l2p>0.0</h2>
         </div>
         <div class=card id=l3>
             <h1 id=power_delivered_l3h>Phase 3</h1>
+            <div class="chart-container" id="container-3">III</div>
+            <hr/>
+            <div style="text-align:center">Kilowatt</div>
             <h2 id=power_delivered_l3>0.0</h2>
-            <h3><span id=power_delivered_l3a>0</span><span> Amp</span></h3>
             <h2 id=power_delivered_l3p>0.0</h2>
         </div>
+        <div class=card id=l4>
+            <h1 id=power_delivered_th>Total</h1>
+            <div class="chart-container" id="container-t">IV</div>
+            <hr/>
+            <div style="text-align:center">Kilowatt</div>
+            <h2 id="power_delivered_t">0.0</h2>
+        </div>
     </div>    
+    <script src="hjm.js"></script>
     <script>
         update() // fill fist-time data
-        var timer = setInterval(update, 10 * 1000) // update every 10 seconds
+        var timer = setInterval(update, 3 * 1000) // update every n seconds
     </script>
 </body> 
 </html>

--- a/data/HJMindex.html
+++ b/data/HJMindex.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<head>
+    <meta charset=utf-8>
+    <meta http-equiv=X-UA-Compatible content="IE=edge">
+    <meta name=viewport content="width=device-width,initial-scale=1">
+    <link rel=icon href=/favicon.ico> <title>kW trend</title>
+    <link href="https://fonts.googleapis.com/css?family=Dosis:400,700" rel="stylesheet">
+    <link href="hjm.css" rel="stylesheet">
+    <script src="hjm.js"></script>
+</head>
+  
+<body><noscript><strong>Please enable JavaScript to continue.</strong></noscript>
+    <div class=outer>
+        <div class=card id=l1>
+            <h1 id=power_delivered_l1h>Phase 1</h1>
+            <h2 id=power_delivered_l1>0.0</h2>
+            <h3><span id=power_delivered_l1a>0</span><span> Amp</span></h3>
+            <h2 id=power_delivered_l1p>0.0</h2>
+        </div>
+        <div class=card id=l2>
+            <h1 id=power_delivered_l2h>Phase 2</h1>
+            <h2 id=power_delivered_l2>0.0</h2>
+            <h3><span id=power_delivered_l2a>0</span><span> Amp</span></h3>
+            <h2 id=power_delivered_l2p>0.0</h2>
+        </div>
+        <div class=card id=l3>
+            <h1 id=power_delivered_l3h>Phase 3</h1>
+            <h2 id=power_delivered_l3>0.0</h2>
+            <h3><span id=power_delivered_l3a>0</span><span> Amp</span></h3>
+            <h2 id=power_delivered_l3p>0.0</h2>
+        </div>
+    </div>    
+    <script>
+        update() // fill fist-time data
+        var timer = setInterval(update, 10 * 1000) // update every 10 seconds
+    </script>
+</body> 
+</html>

--- a/data/HJMindex.html
+++ b/data/HJMindex.html
@@ -21,7 +21,8 @@
             <hr/>
             <div style="text-align:center">Kilowatt</div>
             <h2 id="power_delivered_l1">0.0</h2>
-            <h2 id="power_delivered_l1p">0.0</h2>
+            <h3>max: <span id="power_delivered_1max">0.0</span></h3>
+            <h3>min: <span id="power_delivered_1min">0.0</span></h3>
         </div>
         <div class=card id=l2>
             <h1 id=power_delivered_l2h>Phase 2</h1>
@@ -29,7 +30,8 @@
             <hr/>
             <div style="text-align:center">Kilowatt</div>
             <h2 id=power_delivered_l2>0.0</h2>
-            <h2 id=power_delivered_l2p>0.0</h2>
+            <h3>max: <span id="power_delivered_2max">0.0</span></h3>
+            <h3>min: <span id="power_delivered_2min">0.0</span></h3>
         </div>
         <div class=card id=l3>
             <h1 id=power_delivered_l3h>Phase 3</h1>
@@ -37,7 +39,8 @@
             <hr/>
             <div style="text-align:center">Kilowatt</div>
             <h2 id=power_delivered_l3>0.0</h2>
-            <h2 id=power_delivered_l3p>0.0</h2>
+            <h3>max: <span id="power_delivered_3max">0.0</span></h3>
+            <h3>min: <span id="power_delivered_3min">0.0</span></h3>
         </div>
         <div class=card id=l4>
             <h1 id=power_delivered_th>Total</h1>
@@ -45,6 +48,8 @@
             <hr/>
             <div style="text-align:center">Kilowatt</div>
             <h2 id="power_delivered_t">0.0</h2>
+            <h3>max: <span id="power_delivered_tmax">0.0</span></h3>
+            <h3>min: <span id="power_delivered_tmin">0.0</span></h3>
         </div>
     </div>    
     <script src="hjm.js"></script>

--- a/data/hjm.css
+++ b/data/hjm.css
@@ -1,0 +1,69 @@
+* {
+	box-sizing: border-box
+}
+  
+html {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: 'Dosis', sans-serif;
+	line-height: 1.6;
+	color: #666;
+	background: #F6F6F6;
+}
+ 
+.outer {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+@media screen and (min-width: 600px) {
+	.card {
+	  flex: 1 1 calc(50% - 2rem);
+	}
+}
+  
+@media screen and (min-width: 900px) {
+	.card {
+	  flex: 1 1 calc(33% - 2rem);
+	}
+}
+
+.card {
+	margin: 1rem;
+	background: white;
+	box-shadow: 2px 4px 25px rgba(0, 0, 0, .1);
+	border-radius: 12px;
+	overflow: hidden;
+	transition: all .2s linear;
+	max-width: 200px;  
+	min-width: 180px;
+}
+
+.card:hover {
+	box-shadow: 2px 8px 45px rgba(0, 0, 0, .15);
+	transform: translate3D(0, -2px, 0);
+}
+  
+h1 {
+	text-align: center;
+	padding: 0.5rem 1.5rem;
+	background: #314b77;
+	margin: 0 0 0rem 0;
+	font-size: 1.5rem;
+	color: white;
+}
+
+h2 {
+	text-align: center;
+	font-size: 3rem;
+	padding: 0.2rem 0.2rem;	
+	margin: 0;
+}
+
+h3 {
+	text-align: center;
+	font-size: 1.3rem;
+	font-family: 'Heiti TC';
+	padding: 0.2rem 0.2rem;	
+	margin: 0;
+}

--- a/data/hjm.css
+++ b/data/hjm.css
@@ -14,6 +14,7 @@ html {
 .outer {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: center;
 }
 
 @media screen and (min-width: 600px) {
@@ -43,7 +44,13 @@ html {
 	box-shadow: 2px 8px 45px rgba(0, 0, 0, .15);
 	transform: translate3D(0, -2px, 0);
 }
-  
+
+.chart-container {
+	width: 200px;
+	float: none;
+	height: 180px;
+}
+
 h1 {
 	text-align: center;
 	padding: 0.5rem 1.5rem;
@@ -66,4 +73,9 @@ h3 {
 	font-family: 'Heiti TC';
 	padding: 0.2rem 0.2rem;	
 	margin: 0;
+}
+
+hr {
+	width: 80%;
+	opacity: 0.5;
 }

--- a/data/hjm.js
+++ b/data/hjm.js
@@ -3,6 +3,9 @@ const AMPS=25
 const PHASES=3
 
 var AmpG = [4];
+var PhaseAmps = [4];
+var MaxAmps = [4];
+var TotalAmps;
 
 var gaugeOptions = {
 
@@ -13,16 +16,17 @@ var gaugeOptions = {
     title: null,
 
     pane: {
-        center: ['50%', '85%'],
+        center: ['50%', '75%'],
         size: '100%',
         startAngle: -90,
         endAngle: 90,
         background: {
             backgroundColor:
                 Highcharts.defaultOptions.legend.backgroundColor || '#EEE',
-            innerRadius: '60%',
-            outerRadius: '80%',
+            innerRadius: '80%',
+            outerRadius: '105%',
             shape: 'arc'
+            //opacity: '30%'
         }
     },
 
@@ -38,7 +42,9 @@ var gaugeOptions = {
             [0.9, '#DF5353'] // red
         ],
         lineWidth: 1,
-        minorTickInterval: null,
+        //minorTickInterval: 'auto',
+        minorTicks: true,
+        // minorTicksWidth: 3px,
         tickAmount: 6,
         title: {
             y: -70
@@ -50,6 +56,8 @@ var gaugeOptions = {
 
     plotOptions: {
         solidgauge: {
+            innerRadius: '85%',
+            opacity: '60%',
             dataLabels: {
                 y: 5,
                 borderWidth: 0,
@@ -71,14 +79,29 @@ var AmpOptions = {
 
     series: [{
         name: 'A',
-        data: [22],
+        data: [0],
         dataLabels: {
             format:
                 '<div style="text-align:center">' +
                 '<span style="font-weight:lighter;font-size:16px;font-family: Dosis">{y} A</span><br/>' +
                 '</div>'
+        },
+        dial: {            
+            rearLength: '5%'
+          
         }
-    }]
+    },{
+
+        name: 'Max',
+        data: [1],
+        innerRadius:'100%',
+        radius: '105%',
+        dataLabels: {
+            enabled: false
+       }
+    },
+
+]
 
 };
 
@@ -87,8 +110,7 @@ function abs(x)
     return (x < 0 ? -x : x);
 }
 
-var PhaseAmps = [4];
-var TotalAmps;
+
 
 function update()
 {
@@ -122,14 +144,25 @@ function update()
                         newValue,
                         myPhase;
                     
-                    myPhase = json.fields[j].name.replace('power_delivered_l','');
+                    myPhase = Number(json.fields[j].name.replace('power_delivered_l',''));
                     
-                    chart = AmpG[Number(myPhase)];
+                    chart = AmpG[myPhase];
                     point = chart.series[0].points[0];
 		               
                     newValue = Math.round(nva*1000.0 ) /1000.0;
                     
-        	        point.update(newValue);
+                    point.update(newValue);
+                    
+                    if (newValue > MaxAmps[myPhase])
+                    {
+                        console.log('new record');
+                        MaxAmps[myPhase] = newValue;
+                        point = AmpG[myPhase].series[1].points[0];
+                        point.update(Math.round(MaxAmps[myPhase]));
+
+                    } else {
+                        console.log ('MaxAmps:', MaxAmps[myPhase])
+                    }
                     
                     // trend coloring
 
@@ -177,14 +210,9 @@ function update()
     }
 }
 
-
-
 AmpG[1] = Highcharts.chart('container-1', Highcharts.merge(gaugeOptions, AmpOptions));
-
 AmpG[2] = Highcharts.chart('container-2', Highcharts.merge(gaugeOptions, AmpOptions));
-
 AmpG[3] = Highcharts.chart('container-3', Highcharts.merge(gaugeOptions, AmpOptions));
-
 AmpG[4] = Highcharts.chart('container-t', Highcharts.merge(gaugeOptions, {
                 yAxis: {
                     min: 00,
@@ -209,3 +237,6 @@ AmpG[4] = Highcharts.chart('container-t', Highcharts.merge(gaugeOptions, {
 
             }));
 
+MaxAmps[1] = 0.0;
+MaxAmps[2] = 0.0;
+MaxAmps[3] = 0.0;

--- a/data/hjm.js
+++ b/data/hjm.js
@@ -1,0 +1,53 @@
+const APIGW='http://'+window.location.host+'/api/';
+function abs(x)
+{
+    return (x < 0 ? -x : x);
+}
+
+function update()
+{
+    for( var i=1 ; i < 4 ; i++ )
+    {
+        fetch(APIGW+"v1/sm/fields/power_delivered_l"+i)
+        .then(response => response.json())
+        .then(json => {
+            for( let j in json.fields ){
+                // console.log(json.fields[j].name+" -- "+ "power_delivered_l"+i.toString())
+                if (json.fields[j].name.startsWith("power_delivered_l"))
+                {
+                    let cv=document.getElementById(json.fields[j].name).innerHTML
+                    let nv=(json.fields[j].value).toFixed(3)
+                    let nva=(json.fields[j].value*1000.0/220.0).toFixed(3)   // estimated amps using fixed voltage
+
+                    // update view
+
+                    document.getElementById(json.fields[j].name+"p").innerHTML = cv.toString();
+                    document.getElementById(json.fields[j].name).innerHTML = nv.toString();
+                    document.getElementById(json.fields[j].name+"a").innerHTML = nva.toString();
+
+                    // trend coloring
+
+                    if(abs(cv - nv) < 0.005)
+                    {
+                        //console.log("value remained the same")
+                        document.getElementById(json.fields[j].name+"h").style.background="#314b77"
+                    } else if( nv > cv )
+                    {
+                        //console.log(json.fields[j].name+"=verhoogd")
+                        document.getElementById(json.fields[j].name+"h").style.background="Red"
+                    } else {
+                        //console.log(json.fields[j].name+"=verlaagd")
+                        document.getElementById(json.fields[j].name+"h").style.background="Green"
+                    }
+                }
+            }
+        })
+        .catch(function(error) {
+            var p = document.createElement('p');
+            p.appendChild(
+            document.createTextNode('Error: ' + error.message)
+            );
+        });
+        
+    }
+}

--- a/data/hjm.js
+++ b/data/hjm.js
@@ -1,31 +1,139 @@
 const APIGW='http://'+window.location.host+'/api/';
+const AMPS=25
+const PHASES=3
+
+var AmpG = [4];
+
+var gaugeOptions = {
+
+    chart: {
+        type: 'solidgauge'
+    },
+
+    title: null,
+
+    pane: {
+        center: ['50%', '85%'],
+        size: '100%',
+        startAngle: -90,
+        endAngle: 90,
+        background: {
+            backgroundColor:
+                Highcharts.defaultOptions.legend.backgroundColor || '#EEE',
+            innerRadius: '60%',
+            outerRadius: '80%',
+            shape: 'arc'
+        }
+    },
+
+    tooltip: {
+        enabled: false
+    },
+
+    // the value axis
+    yAxis: {
+        stops: [
+            [0.1, '#55BF3B'], // green
+            [0.5, '#DDDF0D'], // yellow
+            [0.9, '#DF5353'] // red
+        ],
+        lineWidth: 1,
+        minorTickInterval: null,
+        tickAmount: 6,
+        title: {
+            y: -70
+        },
+        labels: {
+            y: 16
+        }
+    },
+
+    plotOptions: {
+        solidgauge: {
+            dataLabels: {
+                y: 5,
+                borderWidth: 0,
+                useHTML: true
+            }
+        }
+    }
+};
+
+var AmpOptions = {
+    yAxis: {
+        min: 00,
+        max: 25,
+    },
+
+    credits: {
+        enabled: false
+    },
+
+    series: [{
+        name: 'A',
+        data: [22],
+        dataLabels: {
+            format:
+                '<div style="text-align:center">' +
+                '<span style="font-weight:lighter;font-size:16px;font-family: Dosis">{y} A</span><br/>' +
+                '</div>'
+        }
+    }]
+
+};
+
 function abs(x)
 {
     return (x < 0 ? -x : x);
 }
 
+var PhaseAmps = [4];
+var TotalAmps;
+
 function update()
 {
-    for( var i=1 ; i < 4 ; i++ )
+    var phase;
+    for( phase=1 ; phase <= PHASES ; phase++ )
     {
-        fetch(APIGW+"v1/sm/fields/power_delivered_l"+i)
+        fetch(APIGW+"v1/sm/fields/power_delivered_l"+phase)
         .then(response => response.json())
-        .then(json => {
+        .then(json => 
+          {
             for( let j in json.fields ){
                 // console.log(json.fields[j].name+" -- "+ "power_delivered_l"+i.toString())
                 if (json.fields[j].name.startsWith("power_delivered_l"))
                 {
+
                     let cv=document.getElementById(json.fields[j].name).innerHTML
                     let nv=(json.fields[j].value).toFixed(3)
                     let nva=(json.fields[j].value*1000.0/220.0).toFixed(3)   // estimated amps using fixed voltage
 
+                    console.log("about to get elements");
                     // update view
 
                     document.getElementById(json.fields[j].name+"p").innerHTML = cv.toString();
                     document.getElementById(json.fields[j].name).innerHTML = nv.toString();
-                    document.getElementById(json.fields[j].name+"a").innerHTML = nva.toString();
+                    //document.getElementById(json.fields[j].name+"a").innerHTML = nva.toString();
 
+		            // update gauge with actual values
+
+                    var chart,
+                        point,
+                        newValue,
+                        myPhase;
+                    
+                    myPhase = json.fields[j].name.replace('power_delivered_l','');
+                    
+                    chart = AmpG[Number(myPhase)];
+                    point = chart.series[0].points[0];
+		               
+                    newValue = Math.round(nva*1000.0 ) /1000.0;
+                    
+        	        point.update(newValue);
+                    
                     // trend coloring
+
+                    console.log("About to color headings");
 
                     if(abs(cv - nv) < 0.005)
                     {
@@ -39,15 +147,65 @@ function update()
                         //console.log(json.fields[j].name+"=verlaagd")
                         document.getElementById(json.fields[j].name+"h").style.background="Green"
                     }
+
+                    PhaseAmps[myPhase] = newValue;
+                    TotalAmps = 0;
+                    for(t=1; t<= PHASES ; t++)
+                        TotalAmps += PhaseAmps[t];
+
+                    // document.getElementById("power_delivered_ta").innerHTML = TotalAmps.toFixed(3);
+                    document.getElementById("power_delivered_t").innerHTML = (TotalAmps*220.0/1000.0).toFixed(3);
+
+                    chart = AmpG[4];
+                    point = chart.series[0].points[0];
+		               
+                    newValue = Math.round(TotalAmps*1000.0 ) /1000.0;
+                    
+        	        point.update(newValue);
+                    
                 }
             }
-        })
-        .catch(function(error) {
-            var p = document.createElement('p');
-            p.appendChild(
-            document.createTextNode('Error: ' + error.message)
-            );
-        });
+          });
+        //.catch(function(error) {
+        //    var p = document.createElement('p');
+        //    p.appendChild(
+        //    document.createTextNode('Error: ' + error.message)
+        //    );
+        //}
+        //);
         
     }
 }
+
+
+
+AmpG[1] = Highcharts.chart('container-1', Highcharts.merge(gaugeOptions, AmpOptions));
+
+AmpG[2] = Highcharts.chart('container-2', Highcharts.merge(gaugeOptions, AmpOptions));
+
+AmpG[3] = Highcharts.chart('container-3', Highcharts.merge(gaugeOptions, AmpOptions));
+
+AmpG[4] = Highcharts.chart('container-t', Highcharts.merge(gaugeOptions, {
+                yAxis: {
+                    min: 00,
+                    max: 3*AMPS,
+                    
+                },
+
+                credits: {
+                    enabled: false
+                },
+
+                series: [{
+                    name: 'A',
+                    data: [22],
+                    dataLabels: {
+                        format:
+                            '<div style="text-align:center">' +
+                            '<span style="font-weight:lighter;font-size:16px;font-family: Dosis">{y} A</span><br/>' +
+                            '</div>'
+                    }
+                }]
+
+            }));
+


### PR DESCRIPTION
Added GUI for API based logger that displays each phase.

Code is assuming 3 x 25 Amps, change constants in him.js to reflect your setup.

Displays gauge with actual (large inner arc) and max (smaller outside arc) Amps per phase, as well as total.
Displays numeric min/max kW per phase as well as total min/max kW.

min/max values are captured in browser session only, hence the overall min/max values are 'while watching', not captured elsewhere.