### PR TITLE
Allow DSMR UI to be reverse proxied

### DIFF
--- a/data/DSMRindex.js
+++ b/data/DSMRindex.js
@@ -8,7 +8,7 @@
 **  TERMS OF USE: MIT License. See bottom of file.                                                            
 ***************************************************************************      
 */
-  const APIGW='http://'+window.location.host+'/api/';
+  const APIGW=window.location.protocol+'//'+window.location.host+'/api/';
 
   "use strict";
 

--- a/data/hjm.js
+++ b/data/hjm.js
@@ -1,4 +1,4 @@
-const APIGW='http://'+window.location.host+'/api/';
+const APIGW=window.location.protocol+'//'+window.location.host+'/api/';
 const AMPS=25
 const PHASES=3
 

--- a/edge/DSMRindex.js
+++ b/edge/DSMRindex.js
@@ -8,7 +8,7 @@
 **  TERMS OF USE: MIT License. See bottom of file.                                                            
 ***************************************************************************      
 */
-  const APIGW='http://'+window.location.host+'/api/';
+  const APIGW=window.location.protocol+'//'+window.location.host+'/api/';
 
   "use strict";
 


### PR DESCRIPTION
Currently I'm hosting my DSMRlogger UI behind Caddyserver which also handles TLS termination. Unfortuntely this means that all calls that depend on `APIGW` fail because they are hardcoded to go to `http`. 