### PR TITLE
Extended MQTT password to fit more characters

### DIFF
--- a/DSMRloggerAPI.h
+++ b/DSMRloggerAPI.h
@@ -222,7 +222,7 @@ uint8_t   settingTelegramInterval;
 uint8_t   settingSmHasFaseInfo = 1;
 char      settingHostname[30];
 char      settingIndexPage[50];
-char      settingMQTTbroker[101], settingMQTTuser[40], settingMQTTpasswd[30], settingMQTTtopTopic[21];
+char      settingMQTTbroker[101], settingMQTTuser[40], settingMQTTpasswd[40], settingMQTTtopTopic[21];
 int32_t   settingMQTTinterval, settingMQTTbrokerPort;
 String    pTimestamp;
 

--- a/settingsStuff.ino
+++ b/settingsStuff.ino
@@ -223,7 +223,7 @@ void readSettings(bool show)
     }
     if (words[0].equalsIgnoreCase("MQTTbrokerPort"))      settingMQTTbrokerPort    = words[1].toInt();  
     if (words[0].equalsIgnoreCase("MQTTuser"))            strCopy(settingMQTTuser    ,35 ,words[1].c_str());  
-    if (words[0].equalsIgnoreCase("MQTTpasswd"))          strCopy(settingMQTTpasswd  ,25, words[1].c_str());  
+    if (words[0].equalsIgnoreCase("MQTTpasswd"))          strCopy(settingMQTTpasswd  ,35, words[1].c_str());  
     if (words[0].equalsIgnoreCase("MQTTinterval"))        settingMQTTinterval        = words[1].toInt(); 
     if (words[0].equalsIgnoreCase("MQTTtopTopic"))        strCopy(settingMQTTtopTopic, 20, words[1].c_str());  
     
@@ -372,7 +372,7 @@ void updateSetting(const char *field, const char *newValue)
     CHANGE_INTERVAL_MS(reconnectMQTTtimer, 100); // try reconnecting cyclus timer
   }
   if (!stricmp(field, "mqtt_passwd")) {
-    strCopy(settingMQTTpasswd  ,25, newValue);  
+    strCopy(settingMQTTpasswd  ,35, newValue);  
     mqttIsConnected = false;
     CHANGE_INTERVAL_MS(reconnectMQTTtimer, 100); // try reconnecting cyclus timer
   }


### PR DESCRIPTION
My MQTT password (32 characters in length) didn't fit. With this patch it at least accepts that password length.