### PR TITLE
Fix 'settings' input field background issue.

### DIFF
--- a/data/DSMRindex.js
+++ b/data/DSMRindex.js
@@ -1222,7 +1222,7 @@ http://DSMR-API.local/api/v1/dev/settings</pre>", false);
                     }
                     sInput.setAttribute("value", data[i].value);
                     sInput.addEventListener('change',
-                                function() { setBackGround("setFld_"+data[i].name, "lightgray"); },
+                                function() { setBackGround(this.id, "lightgray"); },
                                             false
                                 );
                   inputDiv.appendChild(sInput);


### PR DESCRIPTION
On the field 'mqtt topic' i got a javascript error that data[i].name was undefined. This was only used for setting the background color and 'this.id' has the same effect which doesn't cause an error.