### PR TITLE
Create HA_Configuration.yaml

### DIFF
--- a/HA_Configuration.yaml
+++ b/HA_Configuration.yaml
@@ -1,0 +1,89 @@
+rest:
+  - resource: http://dsmr-api.local/api/v1/sm/actual  
+    scan_interval: 10
+    sensor:
+      - name: DSMR LastUpdate
+        value_template: >
+         {{ as_local(strptime(value_json.actual[0].value[0:12], "%y%m%d%H%M%S")) }}
+        device_class: "Timestamp"
+      - name: DSMR Energy Consumption Tariff 1
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'energy_delivered_tariff1') | map(attribute='value') | first | float }}"
+        device_class: "energy"
+        state_class: "total_increasing"
+        unit_of_measurement: "kWh"
+      - name: DSMR Energy Consumption Tariff 2
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'energy_delivered_tariff2') | map(attribute='value') | first | float }}"
+        device_class: "energy"
+        unit_of_measurement: "kWh"
+        state_class: "total_increasing"
+      - name: DSMR Energy Returned Tariff 1
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'energy_returned_tariff1') | map(attribute='value') | first | float }}"
+        device_class: "energy"
+        unit_of_measurement: "kWh"
+        state_class: "total_increasing"
+      - name: DSMR Energy Returned Tariff 2
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'energy_returned_tariff2') | map(attribute='value') | first | float }}"
+        device_class: "energy"
+        unit_of_measurement: "kWh"
+        state_class: "total_increasing"
+      - name: DSMR Power Consumption Actual Total
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_delivered') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Power Returned Actual Total
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_returned') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Voltage Phase 1
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'voltage_l1') | map(attribute='value') | first | float }}"
+        device_class: "voltage"
+        unit_of_measurement: "V"
+      - name: DSMR Voltage Phase 2
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'voltage_l2') | map(attribute='value') | first | float }}"
+        device_class: "voltage"
+        unit_of_measurement: "V"
+      - name: DSMR Voltage Phase 3
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'voltage_l3') | map(attribute='value') | first | float }}"
+        device_class: "voltage"
+        unit_of_measurement: "V"
+      - name: DSMR Current Phase 1
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'current_l1') | map(attribute='value') | first | float }}"
+        device_class: "current"
+        unit_of_measurement: "A"
+      - name: DSMR Current Phase 2
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'current_l2') | map(attribute='value') | first | float }}"
+        device_class: "current"
+        unit_of_measurement: "A"
+      - name: DSMR Current Phase 3
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'current_l3') | map(attribute='value') | first | float }}"
+        device_class: "current"
+        unit_of_measurement: "A"
+      - name: DSMR Power Consumption Phase 1
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_delivered_l1') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Power Consumption Phase 2
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_delivered_l2') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Power Consumption Phase 3
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_delivered_l3') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Power Returned Phase 1
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_returned_l1') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Power Returned Phase 2
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_returned_l2') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Power Returned Phase 3
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'power_returned_l3') | map(attribute='value') | first | float }}"
+        device_class: "power"
+        unit_of_measurement: "kW"
+      - name: DSMR Gas Consumption
+        value_template: "{{ value_json.actual | selectattr('name', 'eq', 'gas_delivered') | map(attribute='value') | first | float }}"
+        device_class: "gas"
+        state_class: "total_increasing"
+        unit_of_measurement: "m³"


### PR DESCRIPTION
Zoals gemeld op blog post comment, maar hierbij in de goede YAML layout.

@mrWheel 

Het veranderen van het netwerk (zie hierboven) gelijk gebruikt om de integratie met Home Assistant te verbeteren. Mijn oorspronkelijke configuratie was een door ontwikkelde versie van de instructie uit jouw Gitbook.

In de oorspronkelijke instructie staat een mengelmoes van MQTT en API integraties en alle waardes worden met een afzonderlijke API call opgehaald. Dit vond de DSMR Reader (V4.5) bij mij niet fijn, als ik alle waardes naar HA bracht, kon die het simpelweg niet meer aan.

Nu zit alles in 1 API call, m.u.v. timestamp worden de waarde op de JSON value gevonden, i.p.v. de regel in de JSON, de juiste device classes, state classes en unit of measurement zijn aangepast om weer in lijn te zijn met Home Assistant 2022.2; waardoor met deze configuratie ook gelijk Energy Management gebruikt kan worden in HA.